### PR TITLE
feat: v26 landing page — final design

### DIFF
--- a/src/pages/v24.astro
+++ b/src/pages/v24.astro
@@ -1,0 +1,196 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Icon from '../components/Icon.astro';
+---
+
+<Layout title="V24 — Final Polish">
+  <div class="min-h-screen bg-[#faf9f7]">
+    <main class="max-w-[960px] mx-auto px-6 pt-14 sm:pt-20">
+
+      <!-- Hero -->
+      <section class="flex flex-col md:flex-row gap-10 md:gap-16 mb-16">
+
+        <!-- Left: Identity -->
+        <div class="md:w-1/2">
+          <div class="flex items-center gap-5 mb-6">
+            <img
+              src="/photo.jpg"
+              alt="Denis Tomilin"
+              class="w-20 h-20 rounded-full object-cover ring-2 ring-coral/20 shadow-lg shrink-0"
+            />
+            <div>
+              <h1 class="text-2xl font-bold leading-tight text-gray-900">Denis Tomilin</h1>
+              <p class="text-sm text-gray-500 mt-1">AI Architect · Consultant · Researcher</p>
+            </div>
+          </div>
+
+          <p class="text-xl font-semibold leading-snug text-gray-900 mb-4">
+            I architect Agentic AI systems and help enterprises <span class="text-coral">actually ship them</span>.
+          </p>
+
+          <p class="text-[15px] text-gray-500 leading-relaxed mb-6">
+            Solutions Architect at <a href="https://dataart.com" class="text-coral hover:text-coral-hover font-medium transition-colors" target="_blank" rel="noopener">DataArt</a>,
+            collaborating on the AI Lab — multi-agent systems, MCP patterns, and Claude Code tooling from prototype to production.
+          </p>
+
+          <!-- Career arc -->
+          <p class="text-[13px] text-gray-500 font-mono mb-2">
+            <span class="text-coral font-semibold">18+ years:</span> C/C++ game dev → Python lead → Architect → CTO → AI Architect
+          </p>
+          <p class="text-[13px] text-gray-400 mb-6">Guitarist · ethical hacker background · traveler</p>
+
+          <div class="flex items-center gap-4">
+            <a href="https://linkedin.com/in/denistomilin-28866686" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="LinkedIn">
+              <Icon name="linkedin" size={20} />
+            </a>
+            <a href="https://github.com/iorlas" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="GitHub">
+              <Icon name="github" size={20} />
+            </a>
+            <a href="https://x.com/iorlasd" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="X">
+              <Icon name="twitter" size={20} />
+            </a>
+            <a href="mailto:dt0xff@gmail.com" class="text-gray-400 hover:text-coral transition-colors" aria-label="Email">
+              <Icon name="mail" size={20} />
+            </a>
+          </div>
+        </div>
+
+        <!-- Right: Credentials + Stripe highlight -->
+        <div class="md:w-1/2 md:pt-2">
+          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-3">Credentials</h2>
+
+          <div class="flex flex-wrap gap-2 mb-4">
+            <span class="inline-flex items-center gap-1.5 text-[13px] font-medium text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap">
+              <Icon name="building" size={13} class="text-coral" />
+              DataArt · since 2017
+            </span>
+            <span class="inline-flex items-center gap-1.5 text-[13px] font-medium text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap">
+              <Icon name="zap" size={13} class="text-coral" />
+              Ex-CTO, Grand Capital
+            </span>
+            <a href="https://stripecertifications.credential.net/026ed691-e891-4a49-9d36-65bcfe44c31a" class="inline-flex items-center gap-1.5 text-[13px] font-semibold text-coral bg-red-50 border border-coral/20 rounded-full px-4 py-2 whitespace-nowrap hover:bg-red-100 transition-colors" target="_blank" rel="noopener">
+              <Icon name="award" size={13} class="text-coral" />
+              Stripe Certified Architect · pre-launch pilot
+            </a>
+            <span class="inline-flex items-center gap-1.5 text-[13px] font-medium text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap">
+              <Icon name="globe" size={13} class="text-coral" />
+              Leading AI, Python & JS at DataArt
+            </span>
+          </div>
+          <p class="text-[12px] text-gray-400 leading-relaxed">
+            First external Stripe certification recipient. Co-developed the program during pre-launch pilot.
+          </p>
+        </div>
+      </section>
+
+      <!-- Projects + Writing -->
+      <div class="pt-8 flex flex-col md:flex-row gap-14 mb-16">
+
+        <!-- Projects -->
+        <section class="md:w-1/2">
+          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-5">Projects</h2>
+          <div class="space-y-7">
+            <a href="https://github.com/iorlas" class="flex items-start gap-4 group" target="_blank" rel="noopener">
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+                <Icon name="brain" size={17} class="text-coral" />
+              </div>
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors flex items-center gap-1.5">
+                  iorlas-kay
+                  <Icon name="arrow-up-right" size={12} class="text-gray-300 group-hover:text-coral transition-colors" />
+                </p>
+                <p class="text-[13px] text-gray-500 leading-relaxed mt-1">Personal knowledge OS — semantic search, entity resolution, structured capture. Built with Claude Code.</p>
+              </div>
+            </a>
+
+            <a href="https://github.com/iorlas" class="flex items-start gap-4 group" target="_blank" rel="noopener">
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+                <Icon name="lightbulb" size={17} class="text-coral" />
+              </div>
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors flex items-center gap-1.5">
+                  iorlas-brainstorm
+                  <Icon name="arrow-up-right" size={12} class="text-gray-300 group-hover:text-coral transition-colors" />
+                </p>
+                <p class="text-[13px] text-gray-500 leading-relaxed mt-1">Decision coaching skill for Claude Code. Detects your reasoning pattern — rationalizing, over-analyzing, genuinely torn — and applies the right technique.</p>
+              </div>
+            </a>
+          </div>
+        </section>
+
+        <!-- Writing -->
+        <section class="md:w-1/2">
+          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-5">Writing</h2>
+          <div class="space-y-7">
+            <a href="https://www.dataart.team/articles/guide-to-agentic-ai-autonomous-systems" class="flex items-start gap-4 group" target="_blank" rel="noopener">
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+                <Icon name="pen-line" size={17} class="text-coral" />
+              </div>
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors flex items-center gap-1.5">
+                  AI Agents: Cutting Through the Noise
+                  <Icon name="arrow-up-right" size={12} class="text-gray-300 group-hover:text-coral transition-colors" />
+                </p>
+                <p class="text-[13px] text-gray-500 leading-relaxed mt-1">A practical guide to Agentic AI and autonomous systems. <span class="text-coral/70 font-mono text-[11px]">2024 · DataArt</span></p>
+              </div>
+            </a>
+
+            <a href="https://www.healthcarebusinesstoday.com/superbacteria-the-war-were-going-to-lose-without-ai-and-big-data/" class="flex items-start gap-4 group" target="_blank" rel="noopener">
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+                <Icon name="pen-line" size={17} class="text-coral" />
+              </div>
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors flex items-center gap-1.5">
+                  Superbacteria: The War We're Going to Lose Without AI and Big Data
+                  <Icon name="arrow-up-right" size={12} class="text-gray-300 group-hover:text-coral transition-colors" />
+                </p>
+                <p class="text-[13px] text-gray-500 leading-relaxed mt-1">On AI in the fight against antimicrobial resistance. <span class="text-coral/70 font-mono text-[11px]">2020 · Healthcare Business Today</span></p>
+              </div>
+            </a>
+          </div>
+        </section>
+
+      </div>
+
+      <!-- Community -->
+      <section class="mb-14">
+        <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-5">Community</h2>
+        <div class="flex items-start gap-4">
+          <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+            <Icon name="users" size={17} class="text-coral" />
+          </div>
+          <div>
+            <p class="text-[15px] font-semibold text-gray-800">Leading AI, Python & JS communities at DataArt</p>
+            <p class="text-[13px] text-gray-500 leading-relaxed mt-1">Leader of three internal engineering communities at DataArt — AI, Python, and JavaScript. Run the weekly Global Python Community Session where engineers talk patterns, tools, and practical Agentic AI.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer class="border-t border-gray-200/50 pt-8 pb-12 text-center">
+        <p class="text-[15px] font-medium text-gray-800">Let's talk</p>
+        <p class="text-[13px] text-gray-400 mt-1 mb-5">Agentic AI, architecture, and interesting problems.</p>
+        <div class="flex flex-wrap justify-center gap-2.5 mb-6">
+          <a href="https://linkedin.com/in/denistomilin-28866686" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
+            <Icon name="linkedin" size={14} class="text-coral" />
+            LinkedIn
+          </a>
+          <a href="https://github.com/iorlas" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
+            <Icon name="github" size={14} class="text-coral" />
+            GitHub
+          </a>
+          <a href="https://x.com/iorlasd" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
+            <Icon name="twitter" size={14} class="text-coral" />
+            X
+          </a>
+          <a href="mailto:dt0xff@gmail.com" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors">
+            <Icon name="mail" size={14} class="text-coral" />
+            Email
+          </a>
+        </div>
+        <p class="text-[10px] text-gray-300 font-mono">&copy; 2026 Denis Tomilin</p>
+      </footer>
+
+    </main>
+  </div>
+</Layout>

--- a/src/pages/v25.astro
+++ b/src/pages/v25.astro
@@ -1,0 +1,185 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Icon from '../components/Icon.astro';
+---
+
+<Layout title="V25 — Refined">
+  <div class="min-h-screen bg-[#faf9f7]">
+    <main class="max-w-[960px] mx-auto px-6 pt-14 sm:pt-20">
+
+      <!-- Hero -->
+      <section class="flex flex-col md:flex-row gap-10 md:gap-16 mb-16">
+
+        <!-- Left: Identity -->
+        <div class="md:w-1/2">
+          <div class="flex items-center gap-5 mb-6">
+            <img
+              src="/photo.jpg"
+              alt="Denis Tomilin"
+              class="w-20 h-20 rounded-full object-cover ring-2 ring-coral/20 shadow-lg shrink-0"
+            />
+            <div>
+              <h1 class="text-2xl font-bold leading-tight text-gray-900">Denis Tomilin</h1>
+              <p class="text-sm text-gray-500 mt-1">AI Architect · Consultant · Researcher</p>
+            </div>
+          </div>
+
+          <p class="text-xl font-semibold leading-snug text-gray-900 mb-5">
+            I architect Agentic AI systems and help enterprises <span class="text-coral">actually ship them</span>.
+          </p>
+
+          <p class="text-[15px] text-gray-500 leading-relaxed mb-8">
+            One of the leading experts at <a href="https://dataart.com" class="text-coral hover:text-coral-hover font-medium transition-colors" target="_blank" rel="noopener">DataArt</a>'s AI Lab — shipping multi-agent systems with LangGraph, Agno, OpenClaw, MCP, mem0, and Claude Code to production.
+          </p>
+
+          <!-- Career arc + personal -->
+          <div class="border-l-2 border-coral/30 pl-4 mb-8">
+            <p class="text-[13px] text-gray-600 font-mono">
+              <span class="text-coral font-semibold">18+ years:</span> C/C++ game dev → Python lead → Architect → CTO → AI Architect
+            </p>
+            <p class="text-[13px] text-gray-400 mt-1">Guitarist · ethical hacker background · traveler</p>
+          </div>
+
+          <div class="flex items-center gap-4">
+            <a href="https://linkedin.com/in/denistomilin-28866686" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="LinkedIn">
+              <Icon name="linkedin" size={20} />
+            </a>
+            <a href="https://github.com/iorlas" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="GitHub">
+              <Icon name="github" size={20} />
+            </a>
+            <a href="https://x.com/iorlasd" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="X">
+              <Icon name="twitter" size={20} />
+            </a>
+            <a href="mailto:dt0xff@gmail.com" class="text-gray-400 hover:text-coral transition-colors" aria-label="Email">
+              <Icon name="mail" size={20} />
+            </a>
+          </div>
+        </div>
+
+        <!-- Right: Credentials -->
+        <div class="md:w-1/2 md:pt-2">
+          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-3">Credentials</h2>
+
+          <div class="flex flex-wrap gap-2 mb-3">
+            <span class="inline-flex items-center gap-1.5 text-[13px] font-medium text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap">
+              <Icon name="building" size={13} class="text-coral" />
+              DataArt · since 2017
+            </span>
+            <span class="inline-flex items-center gap-1.5 text-[13px] font-medium text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap">
+              <Icon name="zap" size={13} class="text-coral" />
+              Ex-CTO, Grand Capital
+            </span>
+            <a href="https://stripecertifications.credential.net/026ed691-e891-4a49-9d36-65bcfe44c31a" class="inline-flex items-center gap-1.5 text-[13px] font-semibold text-coral bg-red-50 border border-coral/20 rounded-full px-4 py-2 whitespace-nowrap hover:bg-red-100 transition-colors" target="_blank" rel="noopener">
+              <Icon name="award" size={13} class="text-coral" />
+              Stripe Certified Architect · pre-launch pilot
+            </a>
+            <span class="inline-flex items-center gap-1.5 text-[13px] font-medium text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap">
+              <Icon name="globe" size={13} class="text-coral" />
+              Leading AI, Python & JS at DataArt
+            </span>
+          </div>
+
+          <!-- Community inline with credentials -->
+          <p class="text-[13px] text-gray-500 leading-relaxed mt-4">
+            Leader of three internal engineering communities at DataArt — AI, Python, and JavaScript. Run the weekly Global Python Community Session.
+          </p>
+        </div>
+      </section>
+
+      <!-- Projects + Writing -->
+      <div class="flex flex-col md:flex-row gap-14 md:gap-20 mb-16">
+
+        <!-- Projects -->
+        <section class="md:w-1/2">
+          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-5">Projects</h2>
+          <div class="space-y-8">
+            <a href="https://github.com/iorlas" class="flex items-start gap-4 group" target="_blank" rel="noopener">
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+                <Icon name="brain" size={17} class="text-coral" />
+              </div>
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors flex items-center gap-1.5">
+                  iorlas-kay
+                  <Icon name="arrow-up-right" size={12} class="text-gray-300 group-hover:text-coral transition-colors" />
+                </p>
+                <p class="text-[13px] text-gray-500 leading-relaxed mt-1">Personal knowledge OS — semantic search, entity resolution, structured capture. Built with Claude Code.</p>
+              </div>
+            </a>
+
+            <a href="https://github.com/iorlas" class="flex items-start gap-4 group" target="_blank" rel="noopener">
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+                <Icon name="lightbulb" size={17} class="text-coral" />
+              </div>
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors flex items-center gap-1.5">
+                  iorlas-brainstorm
+                  <Icon name="arrow-up-right" size={12} class="text-gray-300 group-hover:text-coral transition-colors" />
+                </p>
+                <p class="text-[13px] text-gray-500 leading-relaxed mt-1">Decision coaching skill for Claude Code. Detects your reasoning pattern and applies the right technique.</p>
+              </div>
+            </a>
+          </div>
+        </section>
+
+        <!-- Writing -->
+        <section class="md:w-1/2">
+          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-5">Writing</h2>
+          <div class="space-y-8">
+            <a href="https://www.dataart.team/articles/guide-to-agentic-ai-autonomous-systems" class="flex items-start gap-4 group" target="_blank" rel="noopener">
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+                <Icon name="pen-line" size={17} class="text-coral" />
+              </div>
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors">
+                  AI Agents: Cutting Through the Noise
+                </p>
+                <p class="text-[13px] text-gray-500 leading-relaxed mt-1">A practical guide to Agentic AI and autonomous systems.</p>
+                <p class="text-coral font-mono text-[12px] mt-1">2024 · DataArt</p>
+              </div>
+            </a>
+
+            <a href="https://www.healthcarebusinesstoday.com/superbacteria-the-war-were-going-to-lose-without-ai-and-big-data/" class="flex items-start gap-4 group" target="_blank" rel="noopener">
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-coral/10 flex items-center justify-center mt-0.5">
+                <Icon name="pen-line" size={17} class="text-coral" />
+              </div>
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors">
+                  Superbacteria: The War We're Going to Lose Without AI and Big Data
+                </p>
+                <p class="text-[13px] text-gray-500 leading-relaxed mt-1">On AI in the fight against antimicrobial resistance.</p>
+                <p class="text-coral font-mono text-[12px] mt-1">2020 · Healthcare Business Today</p>
+              </div>
+            </a>
+          </div>
+        </section>
+
+      </div>
+
+      <!-- Footer -->
+      <footer class="border-t border-gray-200/50 pt-10 pb-14 text-center">
+        <p class="text-lg font-semibold text-gray-800 mb-1">Let's talk</p>
+        <p class="text-[14px] text-gray-400 mb-6">Agentic AI, architecture, and interesting problems.</p>
+        <div class="flex flex-wrap justify-center gap-2.5 mb-6">
+          <a href="https://linkedin.com/in/denistomilin-28866686" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
+            <Icon name="linkedin" size={14} class="text-coral" />
+            LinkedIn
+          </a>
+          <a href="https://github.com/iorlas" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
+            <Icon name="github" size={14} class="text-coral" />
+            GitHub
+          </a>
+          <a href="https://x.com/iorlasd" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
+            <Icon name="twitter" size={14} class="text-coral" />
+            X
+          </a>
+          <a href="mailto:dt0xff@gmail.com" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors">
+            <Icon name="mail" size={14} class="text-coral" />
+            Email
+          </a>
+        </div>
+        <p class="text-[10px] text-gray-300 font-mono">&copy; 2026 Denis Tomilin</p>
+      </footer>
+
+    </main>
+  </div>
+</Layout>

--- a/src/pages/v26.astro
+++ b/src/pages/v26.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Icon from '../components/Icon.astro';
 ---
 
-<Layout title="Denis Tomilin — AI Architect">
+<Layout title="V26 — Polished">
   <div class="min-h-screen bg-[#faf9f7]">
     <main class="max-w-[960px] mx-auto px-6 pt-14 sm:pt-20">
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,7 @@
   --color-surface-warm: #fdf8f7;
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+  --spacing-col-gap: 20px;
 }
 
 html {


### PR DESCRIPTION
## Summary
- Two-column layout with credential pills, tech stack pills, career arc
- Coral accent on 3 key elements only (tagline, Stripe cert, DataArt link)
- All content corrections applied (18+ years, Stripe framing, community leadership, tools)
- Specific CTA footer
- Includes all design variations (v1-v25) for reference

## Test plan
- [ ] Build passes
- [ ] Site loads at iorlas.com
- [ ] Mobile layout stacks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)