### PR TITLE
Branded social icons + contact form

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,17 +44,17 @@ import Icon from '../components/Icon.astro';
           </div>
 
           <div class="flex items-center gap-4">
-            <a href="https://linkedin.com/in/denistomilin-28866686" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="LinkedIn">
-              <Icon name="linkedin" size={20} />
+            <a href="https://linkedin.com/in/denistomilin-28866686" class="transition-opacity hover:opacity-70" target="_blank" rel="noopener" aria-label="LinkedIn">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="#0A66C2"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
             </a>
-            <a href="https://github.com/iorlas" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="GitHub">
-              <Icon name="github" size={20} />
+            <a href="https://github.com/iorlas" class="transition-opacity hover:opacity-70" target="_blank" rel="noopener" aria-label="GitHub">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="#181717"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
             </a>
-            <a href="https://x.com/iorlasd" class="text-gray-400 hover:text-coral transition-colors" target="_blank" rel="noopener" aria-label="X">
-              <Icon name="twitter" size={20} />
+            <a href="https://x.com/iorlasd" class="transition-opacity hover:opacity-70" target="_blank" rel="noopener" aria-label="X">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="#000000"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
             </a>
-            <a href="mailto:dt0xff@gmail.com" class="text-gray-400 hover:text-coral transition-colors" aria-label="Email">
-              <Icon name="mail" size={20} />
+            <a href="https://forms.gle/otSXYCxvH2au6ngm9" class="transition-opacity hover:opacity-70" target="_blank" rel="noopener" aria-label="Contact">
+              <Icon name="mail" size={20} class="text-coral" />
             </a>
           </div>
         </div>
@@ -166,21 +166,21 @@ import Icon from '../components/Icon.astro';
         <p class="text-lg font-semibold text-gray-800 mb-1">Building with AI agents? Let's compare notes.</p>
         <p class="text-[14px] text-gray-400 mb-6">Always open to conversations about architecture, agentic patterns, and what's actually working.</p>
         <div class="flex flex-wrap justify-center gap-2.5 mb-6">
-          <a href="https://linkedin.com/in/denistomilin-28866686" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
-            <Icon name="linkedin" size={14} class="text-gray-400" />
+          <a href="https://linkedin.com/in/denistomilin-28866686" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-[#0A66C2]/30 hover:text-[#0A66C2] transition-colors" target="_blank" rel="noopener">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="#0A66C2"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
             LinkedIn
           </a>
-          <a href="https://github.com/iorlas" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
-            <Icon name="github" size={14} class="text-gray-400" />
+          <a href="https://github.com/iorlas" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-gray-400 hover:text-gray-900 transition-colors" target="_blank" rel="noopener">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="#181717"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
             GitHub
           </a>
-          <a href="https://x.com/iorlasd" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
-            <Icon name="twitter" size={14} class="text-gray-400" />
+          <a href="https://x.com/iorlasd" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-gray-400 hover:text-gray-900 transition-colors" target="_blank" rel="noopener">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="#000000"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
             X
           </a>
-          <a href="mailto:dt0xff@gmail.com" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-500 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors">
-            <Icon name="mail" size={14} class="text-gray-400" />
-            Email
+          <a href="https://forms.gle/otSXYCxvH2au6ngm9" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
+            <Icon name="mail" size={14} class="text-coral" />
+            Contact
           </a>
         </div>
         <p class="text-[10px] text-gray-300 font-mono">&copy; 2026 Denis Tomilin</p>


### PR DESCRIPTION
## Summary
- Replace generic gray Lucide icons with official brand SVGs (LinkedIn blue, GitHub dark, X black)
- Replace mailto email links with Google Form contact link to prevent spam
- Footer pills hover in brand colors

## Test plan
- [ ] Verify icons render with correct brand colors
- [ ] Verify contact link opens Google Form
- [ ] Check mobile responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)