### PR TITLE
Add travel guides section

### DIFF
--- a/docs/superpowers/specs/2026-03-22-travel-guides-design.md
+++ b/docs/superpowers/specs/2026-03-22-travel-guides-design.md
@@ -1,0 +1,93 @@
+# Travel Guides Section — Design Spec
+
+## Overview
+
+Cheatsheet-style city travel guides for iorlas.com. Denis visits cities, writes practical notes, sends links to friends/colleagues. No blogging, no country-level pages — just city-level reference cards grouped by country.
+
+Growth rate: ~1-2 cities per year.
+
+## URL Scheme
+
+- `/travel` — index page listing all cities grouped by country
+- `/travel/{country}/{city}` — individual city guide (e.g., `/travel/turkiye/istanbul`)
+
+No separate country pages. Country is just a grouping label.
+
+## Content Collection
+
+Directory: `src/content/travel/`
+
+File naming: `{country}--{city}.md` (e.g., `turkiye--istanbul.md`, `turkiye--alanya.md`)
+
+### Frontmatter Schema
+
+```yaml
+title: "Istanbul"         # City name (required)
+country: "Turkiye"        # Country display name (required)
+countrySlug: "turkiye"    # URL slug for country (required)
+citySlug: "istanbul"      # URL slug for city (required)
+lastUpdated: 2026-03-22   # Date of last meaningful update (required)
+draft: false              # Optional, defaults to false
+```
+
+## Template Sections
+
+All sections are optional except the intro paragraph. Each guide is a single markdown file using H2 headings for sections. The layout auto-generates a table of contents from H2s.
+
+Standard sections (order as listed):
+
+1. **Intro** (no heading) — what kind of place, who goes there, vibe
+2. `## Language` — key phrases with pronunciation
+3. `## Money` — cash vs card, ATMs, exchange, price sense
+4. `## Phone / SIM` — eSIM, local SIM, IMEI rules
+5. `## Food` — restaurants, must-eat dishes
+6. `## Shopping` — where to buy what
+7. `## Transport` — local (taxi, public) + airport transfers
+8. `## What to Visit` — sights and tips
+9. `## Scams & Safety` — what to watch for
+
+Authors can add custom sections as needed.
+
+## Pages & Layouts
+
+### `/travel` Index Page
+
+- Lists cities grouped by country
+- Each entry shows: city name (linked), one-line description, last-updated date
+- Sorted by country name, then city name
+- Same minimal style as the rest of iorlas.com (warm bg, clean type)
+
+### City Guide Page
+
+- Title: city name + country
+- Last-updated date below title
+- Table of contents: anchor links to each H2 section (horizontal on mobile, sidebar on desktop if space allows — start with horizontal top anchors for simplicity)
+- Content rendered from markdown
+- Back link to `/travel`
+
+## Navigation Integration
+
+- Add "Travel" link to the footer contact section on the main page
+- Each guide links back to `/travel`
+
+## Migration Plan
+
+Migrate existing content from `_archive/guides/travel/Countries/`:
+
+- `turkiye/istanbul.md` → `src/content/travel/turkiye--istanbul.md`
+- `turkiye/alanya.md` → `src/content/travel/turkiye--alanya.md`
+- Georgia is empty ("TBC") — skip for now
+
+Content cleanup during migration:
+- Convert Docusaurus `:::warning` admonitions to standard markdown (blockquotes or bold text)
+- Strip Docusaurus frontmatter (`sidebar_position`, etc.)
+- Add new frontmatter schema fields
+- Keep all existing content as-is otherwise
+
+## Out of Scope
+
+- Search / filtering (not needed at 1-2 cities/year)
+- Maps or embedded map widgets
+- Comments or ratings
+- RSS feed for travel content
+- Country-level pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "iorlas-com",
       "version": "0.0.1",
       "dependencies": {
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.0.8",
         "lucide-static": "^0.577.0",
@@ -1800,6 +1801,18 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
@@ -2201,6 +2214,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csso": {
@@ -4248,6 +4273,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -5090,6 +5128,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.0.8",
     "lucide-static": "^0.577.0",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,16 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const travel = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/travel' }),
+  schema: z.object({
+    title: z.string(),
+    country: z.string(),
+    countrySlug: z.string(),
+    citySlug: z.string(),
+    lastUpdated: z.coerce.date(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { travel };

--- a/src/content/travel/turkiye--alanya.md
+++ b/src/content/travel/turkiye--alanya.md
@@ -1,0 +1,137 @@
+---
+title: Alanya / Mahmutlar
+country: Turkiye
+countrySlug: turkiye
+citySlug: alanya
+lastUpdated: 2026-03-22
+---
+
+Antalya, Alanya — typical destinations for many europeans during summer time. Prior to 2023 there were a lot of people from Russia and Ukraine. Many Turks speak russian, english, turkish. Since 2023 — things have changed drastically. Now there are a lot of europeans from richer countries — a lot of people from Germany, some people from UK, Spain, Italy.
+
+Anyway, it is a great destination, quite affordable. Nice beaches, infrastructure, cheap food (used to be sooo cheap, but still is cheap enough).
+
+## Language
+
+Common, used everywhere:
+
+- Hello — Merhaba (mehr-hah-bah)
+- Yes — Evet (eh-vet)
+- No — Hayir (hah-yuhr)
+- Thank you — Tesekkur ederim (teh-shehk-kur eh-deh-reem) **or** Tesekkurler (teh-shehk-kur-ler)
+- Bye bye — Gule Gule (goo-leh goo-leh)
+- How much? — Bu ne kadar? (boo neh kah-dar?)
+- Stop! — Dur! (door!) **or** finish (all people understand it)
+- Sorry — Pardon
+- Check, please — Hesap lutfen (heh-sap loot-fen)
+
+**Recommendation** is to start with "Merhaba" all the time — it shows respect to the people. You can end the conversation with "Tesekkurler, bye bye" — people like it a lot!
+
+Also, feel free to talk in english — but simplify it and shorten the sentences. People know english, can speak it, but they are not perfect.
+
+## Money
+
+You will need physical cash for:
+- Bazaars. No way any grandma will have a payment terminal :(
+- Taxis are operated locally by government. Yet, it is quite rare to see taxis with payment terminals there
+
+Avoid exchanging money at airport. There are ATMs — you can give it a try. Take like 200 USD (~7000 TRY) — you will spend it anyway. And it is better to have some cash anyway.
+
+But have a sense of prices: 100 USD ~ 3500 TRY. Can Taxi cost 1000 TRY? Unlikely.
+
+## Phone / SIM
+
+- *Not tested*. You can purchase eSIM before leaving your own country — https://www.turkcell.com.tr/servisler/turkcell-e-sim . It should get activated in like an hour.
+- Purchase like 20 GB eSIM via Airalo, it is quite cheap nowadays.
+- Purchase a sim locally. Arrive to Turkiye. Exit the airport, find the Turkcell or Vodafone authorized office (it will be branded both externally and internally! some shops are faking it), and purchase sim card cheap and fast. Beware: make sure sim card will be purchased to your name, you will need to give your passport.
+
+Also, keep in mind, if you're going to stay in Turkey for less than 90 days, you don't need to register your IMEI. Otherwise, according to Turkish laws, foreigners staying in Turkey for more than 90 days have 90 days to 180 days before the IMEI is blocked.
+
+## Food
+
+Traditional. See Istanbul — pretty much the same.
+
+### Restaurants
+
+The only three places which are totally different and deserve additional attention:
+- [Chaihana #1](https://maps.app.goo.gl/ddZdbwkh8DzR593p9). Asian food. Hand-made noodles, meat, large portions, cheap/moderate cost. IT IS SO DELICIOUS! Better only in Kazakhstan.
+- [Dodo pizza](https://maps.app.goo.gl/W327154DjL6ZYPr26). Western food. Many different combos. Cheap/moderate cost. Very tasty!
+- [Big Chefs](https://maps.app.goo.gl/kbTEkAyfyaVK5Xsd6). Western food, some turkish as well. Ain't cheap, but good quality. Big Chef cafes and restaurants are located in many places across Turkiye.
+
+Also common chains:
+- McDonalds
+- Burger King
+- Arbys
+- Popeyes
+- Pizza Lavazza
+- Little Ceasar Pizza
+- Pide
+
+### Bazaar
+
+https://www.alanya-tours.com/en/blog/bazaar-in-alanya-turkey
+
+We really like bazaar in Mahmutlar. All rotated bazaars are cheap, prices are written on products quite often. But be ready to pay physical money. Typically there is an exchange kiosk or center placed nearby — they change USD or many other currencies to TRY.
+
+Be careful tho: Bazaars are places with so many different people. Make sure your phone, wallet are safe — don't leave an opportunity for pickpockets.
+
+### Must Eat
+
+First time there? Those are the things which you need to try:
+
+- **Lahmacun** — Not for everyone — it is bread soaked in gravy and slices of meat.
+- **Pide** — Turkish pizza, yay!
+- **Baklava** — Sweet pastry
+- **Dolma** — Leaves-wrapped rice, meats
+- **Turkish delight / lokum** — Jelly, sweet cubes. Especially with rose and nar flavored!
+- **FRESH FRUITS!** A LOT! Don't skip a chance, it is dirt cheap there!
+
+## Shopping
+
+### Medicine
+Beware! Pharmacies are closed on weekends — there is only 1 working per city on weekends.
+
+### Water
+Su (water in turkish) better being bought in bottles.
+
+### Food
+Migros, Carrefour, Bim — great places.
+
+## Transport
+
+### Public transportation
+Locally there are some busses, mostly operating during summer time. Operating across the sea shore line only, sometimes could be quite late.
+
+### Taxi
+- **Apps**: **Uber**? No. Maybe it is supported already.
+- **How to find?** Seek yellow devices with a red button on trees, press on it — if red indicator blinks (although it might be quite dim), then it is cool, wait for like 5 mins — it'll get there. Dispatch-service will get this signal and will call a taxi for you from their park.
+- **Working time**: 06:00 - 23:00
+- **Pay**: Almost always cash.
+
+> **Can I be tricked?** Yes. When sitting — check the taxometer. It should be fully seen. Don't be afraid to ask about it. During the drive — check how fast it ticks — it should be consistent. Otherwise call it out, tell to stop, pay it, call another taxi.
+>
+> **Taxometer shows too much already?** Well, don't be a fool the next time. For now — pay what feels like a fair price, tell that you will call a police otherwise (155 or 157).
+
+### Airport transfer
+
+[Transfer24](https://www.724transfer.com/Home) — Driving large minivans — something like 10 seats. Assisting with luggage. Shared-booking. Could be slightly late, but they are always planning shuttles for specific flights, not randomly. So it is highly unlikely to get late to a flight. Booked quite often, never overbooked.
+
+## What to Visit
+
+If you are a cat-person, certainly don't forget to take some cat food with you when doing some trips. Cats there are used to humans, you can even pet them, but be careful — cat-mom's won't like that sometimes.
+
+- [Kleopatra Beach](https://g.co/kgs/xGmuiw8) — Really nice place, nice sand, clean and sound. Beware tho — you might need to pay a fee to "rent the sunbed and umbrella".
+- Mahmutlar beaches — Rocky here and there — be careful.
+- [Alanya park](https://g.co/kgs/qdWTySg) — Great trip to the castle and all around it
+- [Alanya Teleferik](https://www.tripadvisor.com.tr/Attraction_Review-g297961-d12873315-Reviews-Alanya_Teleferik-Alanya_Turkish_Mediterranean_Coast.html) — Cable car with a great view.
+- [Dimcayi](https://www.tripadvisor.com.tr/Attraction_Review-g297961-d3510019-Reviews-Dimcay-Alanya_Turkish_Mediterranean_Coast.html) — Really nice and calm place
+- [Alanya Cat Park](https://www.tripadvisor.com/Attraction_Review-g297961-d13109441-Reviews-Kedi_Evi-Alanya_Turkish_Mediterranean_Coast.html) — There are so many cats, doing some stuff. It is so lovely!
+- [Pirate boat trip](https://www.tripadvisor.com/AttractionProductReview-g297961-d25324745-Alanya_All_Inclusive_Pirate_Boat_Trip_With_Hotel_Transfer-Alanya_Turkish_Mediterra.html) (the link is just an example — try to book it somewhere else, probably). It is lovely. Not great-great, but we liked it a lot, and it is still quite cheap!
+- Some nice tours: https://www.alanya-tours.com/en
+
+## Scams & Safety
+
+- **Anyone handing you anything**: If someone tries to hand you a flower or candy and says it's free, don't take it. Once you're holding it, you pretty much bought it, and nothing is free
+- Beggars
+- Photographers
+- Tour Guides — be careful
+- Wallet snatching

--- a/src/content/travel/turkiye--istanbul.md
+++ b/src/content/travel/turkiye--istanbul.md
@@ -1,0 +1,143 @@
+---
+title: Istanbul
+country: Turkiye
+countrySlug: turkiye
+citySlug: istanbul
+lastUpdated: 2026-03-22
+---
+
+Istanbul — ex-Constantinople. A rich city with a rich history. It is a common transit zone for many EU/Asia trips, but also a nice stay for a quick and cheap shopping time (mostly wear, tech is still expensive there, but some prices might surprise). You will see a lot of different cultures there, but mostly muslim, european, a bit of asian.
+
+Istanbul is so huge — it is thrice the size of Moscow! It is so huge that Google Maps are misleading, a quick trip to a mall might take like 40 minutes just one way!
+
+Istanbul is a great city, but it is worth acknowledging that it lives under the cultural influence: not that many activities are there. Still, there are a lot of non-formal people in the central city (Kadikoy for example), european music bands concerts, stand-ups! Yet, certainly it could be much better, more massive, but cultural "staples" do not allow many things to use the potential turkish people have.
+
+Don't get fooled by the memes and some bad experiences — Turkish people are warm and welcoming, yet struggle a lot here and there because of gov't, economics, and religion "staples".
+
+## Language
+
+Common, used everywhere:
+
+- Hello — Merhaba (mehr-hah-bah)
+- Yes — Evet (eh-vet)
+- No — Hayir (hah-yuhr)
+- Thank you — Tesekkur ederim (teh-shehk-kur eh-deh-reem) **or** Tesekkurler (teh-shehk-kur-ler)
+- Bye bye — Gule Gule (goo-leh goo-leh)
+- How much? — Bu ne kadar? (boo neh kah-dar?)
+- Stop! — Dur! (door!) **or** finish (all people understand it)
+- Sorry — Pardon
+- Check, please — Hesap lutfen (heh-sap loot-fen)
+
+**Recommendation** is to start with "Merhaba" all the time — it shows respect to the people. You can end the conversation with "Tesekkurler, bye bye" — people like it a lot!
+
+Also, feel free to talk in english — but simplify it and shorten the sentences. People know english, can speak it, but they are not perfect.
+
+## Money
+
+You will rarely need to have cash on hand:
+- Bazaars. Be careful, they like to "play a fool" with some nasty prices
+- Taxis are controlled locally by government. Terminals are almost ALL the time there. If it is not — better skip
+
+Avoid exchanging money at airport. There are ATMs — you can give it a try, prefer Vakif (orange) or Ziraat (red) banks. Ing (with a lion) is international, might work as well. Take like 200 USD (~7000 TRY) — you will spend it anyway. And it is better to have some cash anyway. DISAGREE TO USE THE BANK CONVERSION RATE OR PAY ANY SERVICE FEES (if not in urgency).
+
+But have a sense of prices: 100 USD ~ 3700 TRY. Can Taxi cost 1000 TRY running locally? Unlikely. Only from/to an airport or far away.
+
+## Phone / SIM
+
+- *Not tested*. You can purchase eSIM before leaving your own country — https://www.turkcell.com.tr/servisler/turkcell-e-sim . It should get activated in like an hour.
+- Purchase like 20 GB eSIM via Airalo, it is quite cheap nowadays.
+- Purchase a sim locally. Arrive to Turkiye. Exit the airport, find the Turkcell or Vodafone authorized office (it will be branded both externally and internally! some shops are faking it), and purchase sim card cheap and fast. Beware: make sure sim card will be purchased to your name, you will need to give your passport.
+
+Also, keep in mind, if you're going to stay in Turkey for less than 90 days, you don't need to register your IMEI. Otherwise, according to Turkish laws, foreigners staying in Turkey for more than 90 days have 90 days to 180 days before the IMEI is blocked.
+
+## Food
+
+Traditional, yet a lot of european and some asian. Especially in the central city.
+
+### Restaurants
+
+Those are our recommendations:
+- [Big Chefs](https://g.co/kgs/RgzLYvd). Western food, some turkish as well. Ain't cheap, but good quality. Big Chef cafes and restaurants are located in many places across Turkiye.
+- [Dali Burger](https://g.co/kgs/YnrWqxj). Western food, burgers. TASTY!
+- [Salt Chicken](https://g.co/kgs/63zZpXG). Western food, burgers, nice ones.
+
+Also common chains that serve food we like:
+- McDonalds
+- Burger King
+- Arbys
+- Popeyes
+- Pizza Lavazza
+- Little Ceasar Pizza
+- Pide
+
+### Must Eat
+
+First time there? Those are the things which you need to try:
+
+- **Lahmacun** — Not for everyone — it is bread soaked in gravy and slices of meat.
+- **Pide** — Turkish pizza, yay!
+- **Baklava** — Sweet pastry
+- **Dolma** — Leaves-wrapped rice, meats
+- **Turkish delight / lokum** — Jelly, sweet cubes. Especially with rose and nar flavored!
+- **FRESH FRUITS!** A LOT! Don't skip a chance, it is dirt cheap there!
+
+## Shopping
+
+### Medicine
+Beware! Pharmacies are closed on weekends — there is only 1 working per city on weekends.
+
+### Water
+Su (water in turkish) better being bought in bottles.
+
+### Food
+Migros, Carrefour, Bim — great places. Make sure to purchase Baklava and Turkish delight!
+
+## Transport
+
+### Public transportation
+Just use taxi, honestly. Public transportation like Metro, Marmaray, Metrobus require a payment card, but do accept credit cards easily nowadays.
+
+### Taxi
+- **Apps**: **Uber**? Yes, mandatory. **Bi-taxi** is another option, but not as reliable.
+- **Pay**: Credit card. Check it ahead of time!!!
+
+> **Can I be tricked?** Yes. When sitting — check the taxometer. It should be fully seen. Don't be afraid to ask about it. During the drive — check how fast it ticks — it should be consistent. Otherwise call it out, tell to stop, pay it, call another taxi.
+>
+> **Taxometer shows too much already?** Well, don't be a fool the next time. For now — pay what feels like a fair price, tell that you will call a police otherwise (155 or 157).
+
+### Airport transfer
+
+The new airport has a shuttle which goes around the city — [HavaIST](https://www.hava.ist/). It is cheap, reliable, comfy. USE IT!
+
+## What to Visit
+
+If you are a cat-person, certainly don't forget to take some cat food with you when doing some trips. Cats there are used to humans, you can even pet them, but be careful — cat-mom's won't like that sometimes.
+
+- [Basilica Cistern](https://g.co/kgs/ovZbV7Z) — Quite an interesting place
+- [Hagia Sophia](https://g.co/kgs/BaPVBpA) — Very interesting and famous mosque, worth it, although recently became quite expensive if you are not a muslim
+- [Grand Bazaar](https://g.co/kgs/vPKYXRt) — Don't buy anything there, go there for an experience
+- [The Blue Mosque](https://g.co/kgs/WKX3r5j) — Quite a beautiful, iconic mosque
+- [Topkapi Palace Museum](https://g.co/kgs/7GoJz9h) — Very lovely place
+- [Kadikoy](https://g.co/kgs/6ZsTMHL) — a district around it. It is the asian side of the central city. Gorgeous buildings, just walk around it, using Google Maps to seek points of interests! Like, a famous [bull statue](https://g.co/kgs/ubMhQ4U)
+- [Emaar Square Mall](https://g.co/kgs/aj4rKAC) — a really nice mall
+
+Don't purchase tours on streets — look it on TripAdvisor. You do you, but recommendation — discover things on your own!
+
+## Scams & Safety
+
+Istanbul is a safe-ish city, except touristy areas, which you will visit often.
+
+- There are a lot of gypsies in the centre of Istanbul — keep your pockets shut, make sure nothing hangs out, don't even stop, pay any attention, just move on.
+- **"Games"**. If you see a child asking something, or a ball on a street — move on, don't "accept the challenge".
+- Hide your camera or anything expensive — don't give anyone a signal that you are an easy pick
+- If possible, look cheap/normal — no gold/expensive wear
+- If possible, wear your bag at the front — it is strange but safer
+- Don't leave many valuables in your hotel — hide it under your bed, on a shelf, anywhere, or take with you in a bag, ideally in a hidden pocket
+- If someone talks to you in english on the street — move on
+
+### Common scams
+- **Anyone handing you anything**: If someone tries to hand you a flower or candy and says it's free, don't take it. Once you're holding it, you pretty much bought it, and nothing is free
+- Beggars
+- Photographers
+- Tour Guides — be careful
+- Wallet snatching

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -182,6 +182,10 @@ import Icon from '../components/Icon.astro';
             <Icon name="mail" size={14} class="text-coral" />
             Contact
           </a>
+          <a href="/travel" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors">
+            <Icon name="plane" size={14} class="text-gray-400" />
+            Travel Guides
+          </a>
         </div>
         <p class="text-[10px] text-gray-300 font-mono">&copy; 2026 Denis Tomilin</p>
       </footer>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,28 @@ import Icon from '../components/Icon.astro';
 
 <Layout title="Denis Tomilin — AI Architect">
   <div class="min-h-screen bg-[#faf9f7]">
-    <main class="max-w-[960px] mx-auto px-6 pt-14 sm:pt-20">
+
+    <!-- Nav -->
+    <nav class="max-w-[960px] mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#E8585E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M20.341 6.484A10 10 0 0 1 10.266 21.85" />
+          <path d="M3.659 17.516A10 10 0 0 1 13.74 2.152" />
+          <circle cx="12" cy="12" r="3" />
+          <circle cx="19" cy="5" r="2" />
+          <circle cx="5" cy="19" r="2" />
+        </svg>
+        <span class="text-[15px] font-bold text-gray-900">iorlas.com</span>
+      </a>
+      <div class="flex items-center gap-6">
+        <a href="/travel" class="text-[14px] font-bold text-coral hover:text-coral-hover transition-colors">
+          ✈ Travel Guides
+        </a>
+        <a href="https://forms.gle/otSXYCxvH2au6ngm9" class="text-[13px] text-gray-500 hover:text-coral transition-colors" target="_blank" rel="noopener">Contact</a>
+      </div>
+    </nav>
+
+    <main class="max-w-[960px] mx-auto px-6 pt-8 sm:pt-14">
 
       <!-- Hero -->
       <section class="flex flex-col md:flex-row gap-10 md:gap-16 mb-16">
@@ -127,9 +148,9 @@ import Icon from '../components/Icon.astro';
           </div>
         </section>
 
-        <!-- Writing -->
+        <!-- Publications -->
         <section class="md:w-1/2">
-          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-5">Writing</h2>
+          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-5">Publications</h2>
           <div class="space-y-8">
             <a href="https://www.dataart.team/articles/guide-to-agentic-ai-autonomous-systems" class="flex items-start gap-4 group" target="_blank" rel="noopener">
               <div class="shrink-0 w-9 h-9 rounded-lg bg-gray-100 flex items-center justify-center mt-0.5">
@@ -161,6 +182,23 @@ import Icon from '../components/Icon.astro';
 
       </div>
 
+      <!-- Travel Guides -->
+      <section class="mb-16">
+        <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-4">Travel Guides</h2>
+        <a href="/travel" class="block bg-white border border-gray-200 rounded-lg px-6 py-5 hover:border-coral/30 transition-colors group">
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3">
+              <Icon name="plane" size={18} class="text-coral" />
+              <div>
+                <p class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors">City Cheatsheets</p>
+                <p class="text-[12px] text-gray-400 font-mono">Istanbul · Alanya · more coming</p>
+              </div>
+            </div>
+            <Icon name="arrow-right" size={16} class="text-gray-300 group-hover:text-coral transition-colors" />
+          </div>
+        </a>
+      </section>
+
       <!-- Footer -->
       <footer class="border-t border-gray-200/50 pt-10 pb-14 text-center">
         <p class="text-lg font-semibold text-gray-800 mb-1">Building with AI agents? Let's compare notes.</p>
@@ -181,10 +219,6 @@ import Icon from '../components/Icon.astro';
           <a href="https://forms.gle/otSXYCxvH2au6ngm9" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors" target="_blank" rel="noopener">
             <Icon name="mail" size={14} class="text-coral" />
             Contact
-          </a>
-          <a href="/travel" class="inline-flex items-center gap-1.5 text-[13px] font-mono text-gray-600 bg-white border border-gray-200 rounded-full px-4 py-2 whitespace-nowrap hover:border-coral/30 hover:text-coral transition-colors">
-            <Icon name="plane" size={14} class="text-gray-400" />
-            Travel Guides
           </a>
         </div>
         <p class="text-[10px] text-gray-300 font-mono">&copy; 2026 Denis Tomilin</p>

--- a/src/pages/travel/[countrySlug]/[citySlug].astro
+++ b/src/pages/travel/[countrySlug]/[citySlug].astro
@@ -1,0 +1,97 @@
+---
+import { getCollection, render } from 'astro:content';
+import Layout from '../../../layouts/Layout.astro';
+
+export async function getStaticPaths() {
+  const guides = await getCollection('travel', ({ data }) => !data.draft);
+  return guides.map((guide) => ({
+    params: { countrySlug: guide.data.countrySlug, citySlug: guide.data.citySlug },
+    props: { guide },
+  }));
+}
+
+const { guide } = Astro.props;
+const { Content, headings } = await render(guide);
+const tocHeadings = headings.filter((h) => h.depth === 2);
+---
+
+<Layout title={`${guide.data.title}, ${guide.data.country} — Travel Guide`} description={`Practical travel cheatsheet for ${guide.data.title}, ${guide.data.country}`}>
+  <div class="min-h-screen bg-[#faf9f7]">
+    <div class="max-w-[1100px] mx-auto px-6 pt-14 sm:pt-20 pb-16">
+
+      <!-- Back link -->
+      <a href="/travel" class="text-sm font-mono text-gray-400 hover:text-coral transition-colors mb-8 inline-block">&larr; All guides</a>
+
+      <!-- Header -->
+      <h1 class="text-3xl font-bold text-gray-900 mb-1">{guide.data.title}</h1>
+      <p class="text-sm text-gray-400 font-mono mb-10">
+        {guide.data.country} &middot; Updated {guide.data.lastUpdated.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
+      </p>
+
+      <div class="flex gap-12">
+
+        <!-- Sidebar TOC (desktop) -->
+        {tocHeadings.length > 0 && (
+          <nav class="hidden lg:block w-48 shrink-0">
+            <div class="sticky top-20">
+              <p class="text-[10px] font-mono uppercase tracking-widest text-gray-500 mb-3">On this page</p>
+              <ul class="space-y-1.5 border-l border-gray-200">
+                {tocHeadings.map((h) => (
+                  <li>
+                    <a
+                      href={`#${h.slug}`}
+                      class="block pl-3 text-[13px] text-gray-400 hover:text-coral hover:border-l-coral border-l-2 border-transparent -ml-[1px] transition-colors leading-snug py-0.5"
+                    >
+                      {h.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </nav>
+        )}
+
+        <!-- Main content -->
+        <main class="min-w-0 max-w-[720px]">
+
+          <!-- Mobile TOC -->
+          {tocHeadings.length > 0 && (
+            <nav class="lg:hidden mb-10 pb-6 border-b border-gray-200/50">
+              <p class="text-[10px] font-mono uppercase tracking-widest text-gray-500 mb-3">On this page</p>
+              <div class="flex flex-wrap gap-x-4 gap-y-1">
+                {tocHeadings.map((h) => (
+                  <a
+                    href={`#${h.slug}`}
+                    class="text-[13px] text-gray-400 hover:text-coral transition-colors"
+                  >
+                    {h.text}
+                  </a>
+                ))}
+              </div>
+            </nav>
+          )}
+
+          <!-- Content -->
+          <article class="prose prose-gray max-w-none
+            prose-headings:font-bold prose-headings:text-gray-900
+            prose-h2:text-xl prose-h2:mt-12 prose-h2:mb-4 prose-h2:pt-6 prose-h2:border-t prose-h2:border-gray-200/50
+            prose-h3:text-base prose-h3:mt-6 prose-h3:mb-3
+            prose-p:text-[15px] prose-p:leading-relaxed prose-p:text-gray-600
+            prose-li:text-[15px] prose-li:text-gray-600
+            prose-a:text-coral prose-a:no-underline hover:prose-a:underline
+            prose-strong:text-gray-800
+            prose-blockquote:border-l-coral/40 prose-blockquote:bg-coral-light/30 prose-blockquote:rounded-r-lg prose-blockquote:py-3 prose-blockquote:px-4 prose-blockquote:not-italic
+          ">
+            <Content />
+          </article>
+
+          <!-- Footer -->
+          <div class="mt-16 pt-8 border-t border-gray-200/50 text-center">
+            <a href="/travel" class="text-sm font-mono text-gray-400 hover:text-coral transition-colors">&larr; All guides</a>
+          </div>
+        </main>
+
+      </div>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -1,0 +1,63 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../layouts/Layout.astro';
+
+const guides = await getCollection('travel', ({ data }) => !data.draft);
+
+// Group by country
+const byCountry = new Map<string, typeof guides>();
+for (const guide of guides) {
+  const group = byCountry.get(guide.data.country) || [];
+  group.push(guide);
+  byCountry.set(guide.data.country, group);
+}
+
+// Sort countries, then cities within each
+const countries = [...byCountry.entries()]
+  .sort(([a], [b]) => a.localeCompare(b))
+  .map(([country, cities]) => ({
+    country,
+    cities: cities.sort((a, b) => a.data.title.localeCompare(b.data.title)),
+  }));
+---
+
+<Layout title="Travel Guides — Denis Tomilin" description="Practical city travel cheatsheets — food, transport, scams, what to visit">
+  <div class="min-h-screen bg-[#faf9f7]">
+    <main class="max-w-[720px] mx-auto px-6 pt-14 sm:pt-20 pb-16">
+
+      <!-- Back link -->
+      <a href="/" class="text-sm font-mono text-gray-400 hover:text-coral transition-colors mb-8 inline-block">&larr; Home</a>
+
+      <h1 class="text-3xl font-bold text-gray-900 mb-3">Travel Guides</h1>
+      <p class="text-[15px] text-gray-500 leading-relaxed mb-12">
+        Practical cheatsheets from cities I've visited. Language, money, food, transport, scams — everything you need to know before you go.
+      </p>
+
+      {countries.map(({ country, cities }) => (
+        <section class="mb-10">
+          <h2 class="text-xs font-mono uppercase tracking-widest text-gray-400 mb-4">{country}</h2>
+          <div class="space-y-3">
+            {cities.map((guide) => (
+              <a
+                href={`/travel/${guide.data.countrySlug}/${guide.data.citySlug}`}
+                class="flex items-center justify-between bg-white border border-gray-200 rounded-lg px-5 py-4 hover:border-coral/30 transition-colors group"
+              >
+                <span class="text-[15px] font-semibold text-gray-800 group-hover:text-coral transition-colors">
+                  {guide.data.title}
+                </span>
+                <span class="text-xs font-mono text-gray-400">
+                  {guide.data.lastUpdated.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
+                </span>
+              </a>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <!-- Footer -->
+      <div class="mt-8 pt-8 border-t border-gray-200/50 text-center">
+        <a href="/" class="text-sm font-mono text-gray-400 hover:text-coral transition-colors">&larr; Home</a>
+      </div>
+    </main>
+  </div>
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 @theme {
   --color-coral: #E8585E;


### PR DESCRIPTION
## Summary
- Nav bar with orbit logo + prominent coral "Travel Guides" link
- Travel content collection with city guide template (sticky sidebar TOC)
- `/travel` index page, `/travel/turkiye/istanbul`, `/travel/turkiye/alanya`
- Migrated Istanbul & Alanya guides from archive
- Renamed Writing → Publications
- Travel banner on homepage between content and footer
- Installed @tailwindcss/typography

## Test plan
- [ ] Nav bar visible on all pages
- [ ] Travel index groups cities by country
- [ ] City guides render with TOC sidebar on desktop
- [ ] Mobile TOC falls back to inline links
- [ ] Back links work on all travel pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)